### PR TITLE
Make use of helper function Get-BinRoot

### DIFF
--- a/Clojure/tools/chocolateyInstall.ps1
+++ b/Clojure/tools/chocolateyInstall.ps1
@@ -1,17 +1,6 @@
-﻿# import-module C:\Chocolatey\chocolateyInstall\helpers\chocolateyInstaller
+# import-module C:\Chocolatey\chocolateyInstall\helpers\chocolateyInstaller
 
-function get-binRoot() {
-  if($env:chocolatey_bin_root -ne $null) {
-    $binRoot = $env:chocolatey_bin_root
-  }
-  else {
-    $binRoot = 'bin'
-  }
-  
-  return Join-Path $env:systemdrive $binRoot
-}
-
-$binRoot = get-binRoot
+$binRoot = Get-BinRoot
 $clojure_version = '1.2.0'
 $clojure_contrib_version = '1.2.0'
 $jline_version = '1.0'

--- a/Maven/Maven.nuspec
+++ b/Maven/Maven.nuspec
@@ -15,9 +15,6 @@
     <licenseUrl>http://maven.apache.org/license.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>http://upload.wikimedia.org/wikipedia/commons/f/f5/Maven_logo.gif</iconUrl>
-    <dependencies>
-      <dependency id="binroot"/>
-    </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>
 </package>

--- a/Maven/tools/chocolateyInstall.ps1
+++ b/Maven/tools/chocolateyInstall.ps1
@@ -1,16 +1,11 @@
-﻿#cmd> mvn -version
+#cmd> mvn -version
 
 #create folder if not exists
 function CreateFolder ([string]$Path) {
   New-Item -Path $Path -type directory -Force
 }
 
-$binRoot = join-path $env:systemdrive 'bin'
-
-### Using an environment variable to define the bin root until we implement YAML configuration ###
-if($env:chocolatey_bin_root -ne $null){
-  $binRoot = join-path $env:systemdrive $env:chocolatey_bin_root
-}
+$binRoot = Get-BinRoot
 
 CreateFolder($binRoot)
 

--- a/Maven/tools/chocolateyUninstall.ps1
+++ b/Maven/tools/chocolateyUninstall.ps1
@@ -1,9 +1,4 @@
-﻿$binRoot = join-path $env:systemdrive 'bin'
-
-### Using an environment variable to to define the bin root until we implement YAML configuration ###
-if($env:chocolatey_bin_root -ne $null){
-  $binRoot = join-path $env:systemdrive $env:chocolatey_bin_root
-}
+$binRoot = Get-BinRoot
 
 $version = '3.0.5'
 $name = "apache-maven-$version"

--- a/apache.ant/apache.ant.nuspec
+++ b/apache.ant/apache.ant.nuspec
@@ -14,10 +14,6 @@
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>http://www.zoomingin.net/wp-content/uploads/2010/12/Apache-Ant-Logo-java.png</iconUrl>
-    <dependencies>
-      <!-- <dependency id="java" version="" />  -->	  
-	  <dependency id="binRoot"/> 
-    </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>
 </package>

--- a/apache.ant/tools/chocolateyInstall.ps1
+++ b/apache.ant/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿# ant - v
+# ant - v
 
 # Unable to locate tools.jar. Expected to find it in c:\program files (x86)\java\jre6\lib\tools.jar
 # JAVA_HOME > C:\Program Files (x86)\Java\jdk1.6.0_17
@@ -7,12 +7,7 @@ function CreateFolder ([string]$Path) {
   New-Item -Path $Path -type directory -Force
 }
 
-$binRoot = join-path $env:systemdrive 'bin'
-
-### Using an environment variable to to define the bin root until we implement YAML configuration ###
-if($env:chocolatey_bin_root -ne $null){
-  $binRoot = join-path $env:systemdrive $env:chocolatey_bin_root
-}
+$binRoot = Get-BinRoot
 
 CreateFolder($binRoot)
 

--- a/flyway.commandline/flyway.commandline.nuspec
+++ b/flyway.commandline/flyway.commandline.nuspec
@@ -14,9 +14,6 @@
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://github.com/adorepump/chocolatey-packages/raw/master/flyway.commandline/flyway.png</iconUrl>
-    <dependencies>
-      <dependency id="binRoot"/>
-    </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>
 </package>

--- a/flyway.commandline/tools/chocolateyInstall.ps1
+++ b/flyway.commandline/tools/chocolateyInstall.ps1
@@ -1,20 +1,9 @@
-﻿#import-module C:\Chocolatey\chocolateyInstall\helpers\chocolateyInstaller
-
-function get-binRoot() {
-  if($env:chocolatey_bin_root -ne $null) {
-    $binRoot = $env:chocolatey_bin_root
-  }
-  else {
-    $binRoot = 'bin'
-  }
-  
-  return Join-Path $env:systemdrive $binRoot
-}
+#import-module C:\Chocolatey\chocolateyInstall\helpers\chocolateyInstaller
 
 $version = '1.6.1'
 $name = "flyway-commandline-$version"
 $url = "http://flyway.googlecode.com/files/$name-dist.zip"
-$binRoot = get-binRoot
+$binRoot = Get-BinRoot
 $flyway_home = Join-Path $binRoot $name
 $flyway_cmd_source = Join-Path $flyway_home 'flyway.cmd'
 $flyway_cmd_dest = Join-Path $env:CHOCOLATEYINSTALL 'bin\flyway.cmd'


### PR DESCRIPTION
In my Chocolatey installation the chocolatey_bin_root is C:\Tools (as set by Chocolatey itself). Therefore these packages fail to install, since they try to use C:C:\Tools. This change handles both cases.
